### PR TITLE
Tests for division by structures

### DIFF
--- a/wagtail_streamfield_migration_toolkit/operations.py
+++ b/wagtail_streamfield_migration_toolkit/operations.py
@@ -1,0 +1,21 @@
+class BaseBlockOperation:
+    def __init__(self):
+        pass
+
+    def apply_to_stream_child(self, block):
+        raise NotImplementedError
+
+
+class RenameBlockOperation(BaseBlockOperation):
+    def __init__(self, new_name):
+        self.new_name = new_name
+        super().__init__()
+
+        # Not implemented yet
+
+
+class RemoveBlockOperation(BaseBlockOperation):
+    def __init__(self):
+        super().__init__()
+
+        # Not implemented yet

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_block_structure.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_block_structure.py
@@ -12,7 +12,7 @@ from wagtail_streamfield_migration_toolkit.operations import (
 # TODO add asserts for ids
 
 
-class TopLevelTest(TestCase):
+class FieldChildBlockTest(TestCase):
     """Changes to `char1`"""
 
     @classmethod
@@ -59,7 +59,7 @@ class TopLevelTest(TestCase):
         pass
 
 
-class StructNestedTest(TestCase):
+class FieldStructChildBlockTest(TestCase):
     """Changes to `simplestruct.char1`"""
 
     @classmethod
@@ -120,7 +120,7 @@ class StructNestedTest(TestCase):
         self.assertIn("char2", altered_raw_data[2]["value"])
 
 
-class StreamNestedTest(TestCase):
+class FieldStreamChildBlock(TestCase):
     """Changes to `simplestream.char1`"""
 
     @classmethod
@@ -188,7 +188,7 @@ class StreamNestedTest(TestCase):
         self.assertEqual(altered_raw_data[1]["value"][0]["type"], "char2")
 
 
-class StructStreamNestedTest(TestCase):
+class FieldStructStreamChildBlockTest(TestCase):
     """Changes to `nestedstruct.simplestream.char1`"""
 
     @classmethod
@@ -281,7 +281,7 @@ class StructStreamNestedTest(TestCase):
         self.assertEqual("char2", altered_raw_data[1]["value"]["stream1"][0]["type"])
 
 
-class StructStructNestedTest(TestCase):
+class FieldStructStructChildBlockTest(TestCase):
     """Changes to `nestedstruct.simplestruct.char1`"""
 
     @classmethod
@@ -360,19 +360,19 @@ class StructStructNestedTest(TestCase):
         self.assertIn("char2", altered_raw_data[2]["value"]["struct1"])
 
 
-class StreamStreamNestedTest(TestCase):
+class FieldStreamStreamChildBlockTest(TestCase):
     pass
 
 
-class StreamStructNestedTest(TestCase):
+class FieldStreamStructChildBlockTest(TestCase):
     pass
 
 
-class ListStreamNestedTest(TestCase):
+class FieldListStreamChildBlockTest(TestCase):
     pass
 
 
-class ListStructNestedTest(TestCase):
+class FieldListStructChildBlockTest(TestCase):
     """Changes to `nestedlist_struct.char1`"""
 
     @classmethod

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_block_structure.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_block_structure.py
@@ -1,0 +1,396 @@
+from unittest import expectedFailure
+from django.test import SimpleTestCase, TestCase
+
+from .. import factories
+from wagtail_streamfield_migration_toolkit.utils import apply_changes_to_raw_data
+
+
+# TODO add asserts for ids
+
+
+class TopLevelTest(TestCase):
+    """Changes to `char1`"""
+
+    @classmethod
+    def setUpTestData(cls):
+        raw_data = factories.SampleModelFactory(
+            content__0__char1__value="Char Block 1",
+            content__1__char2__value="Char Block 2",
+            content__2__char1__value="Char Block 1",
+        ).content.raw_data
+        cls.raw_data = raw_data
+
+    @expectedFailure
+    def test_rename(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "char1", "rename", new_name="renamed1"
+        )
+
+        self.assertEqual(altered_raw_data[0]["type"], "renamed1")
+        self.assertEqual(altered_raw_data[2]["type"], "renamed1")
+
+        self.assertEqual(altered_raw_data[0]["value"], "Char Block 1")
+        self.assertEqual(altered_raw_data[2]["value"], "Char Block 1")
+
+    def test_rename_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "char1", "rename", new_name="renamed1"
+        )
+
+        self.assertEqual(altered_raw_data[1]["type"], "char2")
+
+    @expectedFailure
+    def test_remove(self):
+        altered_raw_data = apply_changes_to_raw_data(self.raw_data, "char1", "remove")
+
+        self.assertEqual(len(altered_raw_data), 1)
+        self.assertEqual(altered_raw_data[0]["type"], "char2")
+
+    def test_to_listblock(self):
+        pass
+
+    def test_to_streamblock(self):
+        pass
+
+
+class StructNestedTest(TestCase):
+    """Changes to `simplestruct.char1`"""
+
+    @classmethod
+    def setUpTestData(cls):
+        raw_data = factories.SampleModelFactory(
+            content__0__char1__value="Char Block 1",
+            content__1="simplestruct",
+            content__2="simplestruct",
+        ).content.raw_data
+        cls.raw_data = raw_data
+
+    @expectedFailure
+    def test_rename(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "simplestruct.char1", "rename", new_name="renamed1"
+        )
+
+        self.assertNotIn("char1", altered_raw_data[1]["value"])
+        self.assertNotIn("char1", altered_raw_data[2]["value"])
+        self.assertIn("renamed1", altered_raw_data[1]["value"])
+        self.assertIn("renamed1", altered_raw_data[2]["value"])
+
+    def test_rename_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "simplestruct.char1", "rename", new_name="renamed1"
+        )
+
+        self.assertEqual(altered_raw_data[0]["type"], "char1")
+        self.assertEqual(altered_raw_data[1]["type"], "simplestruct")
+        self.assertEqual(altered_raw_data[2]["type"], "simplestruct")
+
+        self.assertIn("char2", altered_raw_data[1]["value"])
+        self.assertIn("char2", altered_raw_data[2]["value"])
+
+    @expectedFailure
+    def test_remove(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "simplestruct.char1", "remove"
+        )
+
+        self.assertEqual(len(altered_raw_data[1]["value"]), 1)
+        self.assertEqual(len(altered_raw_data[2]["value"]), 1)
+        self.assertNotIn("char1", altered_raw_data[1]["value"])
+        self.assertNotIn("char1", altered_raw_data[2]["value"])
+
+    def test_remove_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "simplestruct.char1", "remove"
+        )
+
+        self.assertEqual(len(altered_raw_data), 3)
+
+        self.assertIn("char2", altered_raw_data[1]["value"])
+        self.assertIn("char2", altered_raw_data[2]["value"])
+
+
+class StreamNestedTest(TestCase):
+    """Changes to `simplestream.char1`"""
+
+    @classmethod
+    def setUpTestData(cls):
+        # TODO until support is available from wagtail-factories, manually write.
+        raw_data = [
+            {"type": "char1", "value": "Char Block 1"},
+            {
+                "type": "simplestream",
+                "value": [
+                    {"type": "char1", "value": "Char Block 1"},
+                    {"type": "char2", "value": "Char Block 2"},
+                    {"type": "char1", "value": "Char Block 1"},
+                ],
+            },
+            {
+                "type": "simplestream",
+                "value": [{"type": "char1", "value": "Char Block 1"}],
+            },
+        ]
+        cls.raw_data = raw_data
+
+    @expectedFailure
+    def test_rename(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "simplestream.char1", "rename", "renamed1"
+        )
+
+        self.assertEqual(altered_raw_data[1]["value"][0]["type"], "renamed1")
+        self.assertEqual(altered_raw_data[1]["value"][2]["type"], "renamed1")
+        self.assertEqual(altered_raw_data[2]["value"][0]["type"], "renamed1")
+
+    def test_rename_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "simplestream.char1", "rename", "renamed1"
+        )
+
+        self.assertEqual(altered_raw_data[0]["type"], "char1")
+        self.assertEqual(altered_raw_data[1]["type"], "simplestream")
+        self.assertEqual(altered_raw_data[2]["type"], "simplestream")
+
+        self.assertEqual(altered_raw_data[1]["value"][1]["type"], "char2")
+
+    @expectedFailure
+    def test_remove(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "simplestream.char1", "remove"
+        )
+
+        self.assertEqual(len(altered_raw_data[1]["value"]), 1)
+        self.assertEqual(len(altered_raw_data[2]["value"]), 0)
+
+    @expectedFailure
+    def test_remove_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "simplestream.char1", "remove"
+        )
+
+        self.assertEqual(len(altered_raw_data), 3)
+
+        self.assertEqual(altered_raw_data[1]["value"][0]["type"], "char2")
+
+
+class StructStreamNestedTest(TestCase):
+    """Changes to `nestedstruct.simplestream.char1`"""
+
+    @classmethod
+    def setUpTestData(cls):
+        raw_data = factories.SampleModelFactory(
+            content__0__char1__value="Char Block 1",
+            content__1="nestedstruct",
+            content__1__nestedstruct__list1__value="a",
+            content__2="nestedstruct",
+            content__2__nestedstruct__list1__value="a",
+        ).content.raw_data
+
+        # TODO until support is available from wagtail-factories, manually add the rest.
+        raw_data[1]["value"]["stream1"] = [
+            {"type": "char1", "value": "Char Block 1"},
+            {"type": "char2", "value": "Char Block 2"},
+            {"type": "char1", "value": "Char Block 1"},
+        ]
+        raw_data[2]["value"]["stream1"] = [
+            {"type": "char1", "value": "Char Block 1"},
+        ]
+        raw_data.append(
+            {
+                "type": "simplestream",
+                "value": [
+                    {"type": "char1", "value": "Char Block 1"},
+                    {"type": "char2", "value": "Char Block 2"},
+                ],
+            }
+        )
+
+        cls.raw_data = raw_data
+
+    @expectedFailure
+    def test_rename(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedstruct.stream1.char1", "rename", new_name="renamed1"
+        )
+
+        self.assertEqual(altered_raw_data[1]["value"]["stream1"][0]["type"], "renamed1")
+        self.assertEqual(altered_raw_data[1]["value"]["stream1"][2]["type"], "renamed1")
+        self.assertEqual(altered_raw_data[2]["value"]["stream1"][0]["type"], "renamed1")
+
+    def test_rename_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedstruct.stream1.char1", "rename", new_name="renamed1"
+        )
+
+        self.assertEqual(altered_raw_data[0]["type"], "char1")
+        self.assertEqual(altered_raw_data[1]["type"], "nestedstruct")
+        self.assertEqual(altered_raw_data[2]["type"], "nestedstruct")
+        self.assertEqual(altered_raw_data[3]["type"], "simplestream")
+
+        self.assertIn("char1", altered_raw_data[1]["value"])
+        self.assertIn("stream1", altered_raw_data[1]["value"])
+        self.assertIn("struct1", altered_raw_data[1]["value"])
+        self.assertIn("list1", altered_raw_data[1]["value"])
+
+        self.assertEqual(altered_raw_data[3]["value"][0]["type"], "char1")
+        self.assertEqual(altered_raw_data[3]["value"][1]["type"], "char2")
+
+        self.assertEqual(altered_raw_data[1]["value"]["stream1"][1]["type"], "char2")
+
+    @expectedFailure
+    def test_remove(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedstruct.stream1.char1", "remove"
+        )
+
+        self.assertEqual(len(altered_raw_data[1]["value"]["stream1"]), 1)
+        self.assertEqual(len(altered_raw_data[2]["value"]["stream1"]), 0)
+
+        self.assertNotEqual(altered_raw_data[1]["value"]["stream1"][0]["type"], "char1")
+
+    @expectedFailure
+    def test_remove_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedstruct.stream1.char1", "remove"
+        )
+
+        self.assertEqual(len(altered_raw_data), 4)
+        self.assertEqual(len(altered_raw_data[1]["value"]), 4)
+        self.assertEqual(len(altered_raw_data[2]["value"]), 4)
+        self.assertEqual(len(altered_raw_data[3]["value"]), 2)
+
+        self.assertEqual("char2", altered_raw_data[1]["value"]["stream1"][0]["type"])
+
+
+class StructStructNestedTest(TestCase):
+    """Changes to `nestedstruct.simplestruct.char1`"""
+
+    @classmethod
+    def setUpTestData(cls):
+        raw_data = factories.SampleModelFactory(
+            content__0__char1__value="Char Block 1",
+            content__1="nestedstruct",
+            content__1__nestedstruct__list1__value="a",
+            content__2="nestedstruct",
+            content__2__nestedstruct__list1__value="a",
+            content__3="simplestruct",
+        ).content.raw_data
+        cls.raw_data = raw_data
+
+    @expectedFailure
+    def test_rename(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedstruct.struct1.char1", "rename", new_name="renamed1"
+        )
+
+        self.assertNotIn("char1", altered_raw_data[1]["value"]["struct1"]["value"])
+        self.assertNotIn("char1", altered_raw_data[2]["value"]["struct1"]["value"])
+        self.assertIn("renamed1", altered_raw_data[2]["value"]["struct1"]["value"])
+        self.assertIn("renamed1", altered_raw_data[2]["value"]["struct1"]["value"])
+
+    def test_rename_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedstruct.struct1.char1", "rename", new_name="renamed1"
+        )
+
+        self.assertEqual(len(altered_raw_data), 4)
+
+        self.assertEqual(altered_raw_data[0]["type"], "char1")
+        self.assertEqual(altered_raw_data[1]["type"], "nestedstruct")
+        self.assertEqual(altered_raw_data[2]["type"], "nestedstruct")
+        self.assertEqual(altered_raw_data[3]["type"], "simplestruct")
+
+        self.assertIn("char1", altered_raw_data[1]["value"])
+        self.assertIn("stream1", altered_raw_data[1]["value"])
+        self.assertIn("struct1", altered_raw_data[1]["value"])
+        self.assertIn("list1", altered_raw_data[1]["value"])
+
+        self.assertIn("char1", altered_raw_data[3]["value"])
+        self.assertIn("char2", altered_raw_data[3]["value"])
+
+        self.assertIn("char2", altered_raw_data[1]["value"]["struct1"])
+        self.assertIn("char2", altered_raw_data[2]["value"]["struct1"])
+
+    @expectedFailure
+    def test_remove(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedstruct.struct1.char1", "remove"
+        )
+
+        self.assertEqual(len(altered_raw_data[1]["value"]["struct1"]), 1)
+        self.assertEqual(len(altered_raw_data[2]["value"]["struct1"]), 1)
+
+        self.assertNotIn("char1", altered_raw_data[1]["value"]["struct1"])
+        self.assertNotIn("char1", altered_raw_data[2]["value"]["struct1"])
+
+    def test_remove_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedstruct.struct1.char1", "remove"
+        )
+
+        self.assertEqual(len(altered_raw_data), 4)
+        self.assertEqual(len(altered_raw_data[1]["value"]), 4)
+        self.assertEqual(len(altered_raw_data[2]["value"]), 4)
+        self.assertEqual(len(altered_raw_data[3]["value"]), 2)
+
+        self.assertIn("char2", altered_raw_data[1]["value"]["struct1"])
+        self.assertIn("char2", altered_raw_data[2]["value"]["struct1"])
+
+
+class StreamStreamNestedTest(TestCase):
+    pass
+
+
+class StreamStructNestedTest(TestCase):
+    pass
+
+
+class ListStreamNestedTest(TestCase):
+    pass
+
+
+class ListStructNestedTest(TestCase):
+    """Changes to `nestedlist_struct.char1`"""
+
+    @classmethod
+    def setUpTestData(cls):
+        raw_data = factories.SampleModelFactory(
+            content__0__char1__value="Char Block 1",
+            content__1__nestedlist_struct__0__label="Nested List Struct 1",
+            content__1__nestedlist_struct__1__label="Nested List Struct 2",
+            content__2__nestedlist_struct__0__label="Nested List Struct 3",
+            content__3__simplestruct__label="Simple Struct 1",
+        ).content.raw_data
+        cls.raw_data = raw_data
+
+    @expectedFailure
+    def test_rename(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedlist_struct.char1", "rename", "renamed1"
+        )
+
+        self.assertNotIn("char1", altered_raw_data[1]["value"][0]["value"])
+        self.assertNotIn("char1", altered_raw_data[1]["value"][1]["value"])
+        self.assertNotIn("char1", altered_raw_data[2]["value"][0]["value"])
+
+        self.assertIn("renamed1", altered_raw_data[1]["value"][0]["value"])
+        self.assertIn("renamed1", altered_raw_data[1]["value"][1]["value"])
+        self.assertIn("renamed1", altered_raw_data[2]["value"][0]["value"])
+
+    def test_rename_rest_intact(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "nestedlist_struct.char1", "rename", "renamed1"
+        )
+
+        self.assertEqual(altered_raw_data[0]["type"], "char1")
+        self.assertEqual(altered_raw_data[1]["type"], "nestedlist_struct")
+        self.assertEqual(altered_raw_data[2]["type"], "nestedlist_struct")
+        self.assertEqual(altered_raw_data[3]["type"], "simplestruct")
+
+        self.assertIn("char1", altered_raw_data[3]["value"])
+        self.assertIn("char2", altered_raw_data[3]["value"])
+
+        self.assertIn("char2", altered_raw_data[1]["value"][0]["value"])
+        self.assertIn("char2", altered_raw_data[1]["value"][1]["value"])
+        self.assertIn("char2", altered_raw_data[2]["value"][0]["value"])

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_block_structure.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_block_structure.py
@@ -3,6 +3,10 @@ from django.test import SimpleTestCase, TestCase
 
 from .. import factories
 from wagtail_streamfield_migration_toolkit.utils import apply_changes_to_raw_data
+from wagtail_streamfield_migration_toolkit.operations import (
+    RenameBlockOperation,
+    RemoveBlockOperation,
+)
 
 
 # TODO add asserts for ids
@@ -23,7 +27,7 @@ class TopLevelTest(TestCase):
     @expectedFailure
     def test_rename(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "char1", "rename", new_name="renamed1"
+            self.raw_data, "char1", RenameBlockOperation(new_name="renamed1")
         )
 
         self.assertEqual(altered_raw_data[0]["type"], "renamed1")
@@ -34,14 +38,16 @@ class TopLevelTest(TestCase):
 
     def test_rename_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "char1", "rename", new_name="renamed1"
+            self.raw_data, "char1", RenameBlockOperation(new_name="renamed1")
         )
 
         self.assertEqual(altered_raw_data[1]["type"], "char2")
 
     @expectedFailure
     def test_remove(self):
-        altered_raw_data = apply_changes_to_raw_data(self.raw_data, "char1", "remove")
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data, "char1", RemoveBlockOperation()
+        )
 
         self.assertEqual(len(altered_raw_data), 1)
         self.assertEqual(altered_raw_data[0]["type"], "char2")
@@ -68,7 +74,9 @@ class StructNestedTest(TestCase):
     @expectedFailure
     def test_rename(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "simplestruct.char1", "rename", new_name="renamed1"
+            self.raw_data,
+            "simplestruct.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertNotIn("char1", altered_raw_data[1]["value"])
@@ -78,7 +86,9 @@ class StructNestedTest(TestCase):
 
     def test_rename_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "simplestruct.char1", "rename", new_name="renamed1"
+            self.raw_data,
+            "simplestruct.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertEqual(altered_raw_data[0]["type"], "char1")
@@ -91,7 +101,7 @@ class StructNestedTest(TestCase):
     @expectedFailure
     def test_remove(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "simplestruct.char1", "remove"
+            self.raw_data, "simplestruct.char1", RemoveBlockOperation()
         )
 
         self.assertEqual(len(altered_raw_data[1]["value"]), 1)
@@ -101,7 +111,7 @@ class StructNestedTest(TestCase):
 
     def test_remove_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "simplestruct.char1", "remove"
+            self.raw_data, "simplestruct.char1", RemoveBlockOperation()
         )
 
         self.assertEqual(len(altered_raw_data), 3)
@@ -136,7 +146,9 @@ class StreamNestedTest(TestCase):
     @expectedFailure
     def test_rename(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "simplestream.char1", "rename", "renamed1"
+            self.raw_data,
+            "simplestream.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertEqual(altered_raw_data[1]["value"][0]["type"], "renamed1")
@@ -145,7 +157,9 @@ class StreamNestedTest(TestCase):
 
     def test_rename_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "simplestream.char1", "rename", "renamed1"
+            self.raw_data,
+            "simplestream.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertEqual(altered_raw_data[0]["type"], "char1")
@@ -157,7 +171,7 @@ class StreamNestedTest(TestCase):
     @expectedFailure
     def test_remove(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "simplestream.char1", "remove"
+            self.raw_data, "simplestream.char1", RemoveBlockOperation()
         )
 
         self.assertEqual(len(altered_raw_data[1]["value"]), 1)
@@ -166,7 +180,7 @@ class StreamNestedTest(TestCase):
     @expectedFailure
     def test_remove_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "simplestream.char1", "remove"
+            self.raw_data, "simplestream.char1", RemoveBlockOperation()
         )
 
         self.assertEqual(len(altered_raw_data), 3)
@@ -211,7 +225,9 @@ class StructStreamNestedTest(TestCase):
     @expectedFailure
     def test_rename(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedstruct.stream1.char1", "rename", new_name="renamed1"
+            self.raw_data,
+            "nestedstruct.stream1.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertEqual(altered_raw_data[1]["value"]["stream1"][0]["type"], "renamed1")
@@ -220,7 +236,9 @@ class StructStreamNestedTest(TestCase):
 
     def test_rename_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedstruct.stream1.char1", "rename", new_name="renamed1"
+            self.raw_data,
+            "nestedstruct.stream1.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertEqual(altered_raw_data[0]["type"], "char1")
@@ -241,7 +259,7 @@ class StructStreamNestedTest(TestCase):
     @expectedFailure
     def test_remove(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedstruct.stream1.char1", "remove"
+            self.raw_data, "nestedstruct.stream1.char1", RemoveBlockOperation()
         )
 
         self.assertEqual(len(altered_raw_data[1]["value"]["stream1"]), 1)
@@ -252,7 +270,7 @@ class StructStreamNestedTest(TestCase):
     @expectedFailure
     def test_remove_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedstruct.stream1.char1", "remove"
+            self.raw_data, "nestedstruct.stream1.char1", RemoveBlockOperation()
         )
 
         self.assertEqual(len(altered_raw_data), 4)
@@ -281,7 +299,9 @@ class StructStructNestedTest(TestCase):
     @expectedFailure
     def test_rename(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedstruct.struct1.char1", "rename", new_name="renamed1"
+            self.raw_data,
+            "nestedstruct.struct1.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertNotIn("char1", altered_raw_data[1]["value"]["struct1"]["value"])
@@ -291,7 +311,9 @@ class StructStructNestedTest(TestCase):
 
     def test_rename_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedstruct.struct1.char1", "rename", new_name="renamed1"
+            self.raw_data,
+            "nestedstruct.struct1.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertEqual(len(altered_raw_data), 4)
@@ -315,7 +337,7 @@ class StructStructNestedTest(TestCase):
     @expectedFailure
     def test_remove(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedstruct.struct1.char1", "remove"
+            self.raw_data, "nestedstruct.struct1.char1", RemoveBlockOperation()
         )
 
         self.assertEqual(len(altered_raw_data[1]["value"]["struct1"]), 1)
@@ -326,7 +348,7 @@ class StructStructNestedTest(TestCase):
 
     def test_remove_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedstruct.struct1.char1", "remove"
+            self.raw_data, "nestedstruct.struct1.char1", RemoveBlockOperation()
         )
 
         self.assertEqual(len(altered_raw_data), 4)
@@ -367,7 +389,9 @@ class ListStructNestedTest(TestCase):
     @expectedFailure
     def test_rename(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedlist_struct.char1", "rename", "renamed1"
+            self.raw_data,
+            "nestedlist_struct.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertNotIn("char1", altered_raw_data[1]["value"][0]["value"])
@@ -380,7 +404,9 @@ class ListStructNestedTest(TestCase):
 
     def test_rename_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data, "nestedlist_struct.char1", "rename", "renamed1"
+            self.raw_data,
+            "nestedlist_struct.char1",
+            RenameBlockOperation(new_name="renamed1"),
         )
 
         self.assertEqual(altered_raw_data[0]["type"], "char1")

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_block_structure.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_block_structure.py
@@ -304,10 +304,10 @@ class FieldStructStructChildBlockTest(TestCase):
             RenameBlockOperation(new_name="renamed1"),
         )
 
-        self.assertNotIn("char1", altered_raw_data[1]["value"]["struct1"]["value"])
-        self.assertNotIn("char1", altered_raw_data[2]["value"]["struct1"]["value"])
-        self.assertIn("renamed1", altered_raw_data[2]["value"]["struct1"]["value"])
-        self.assertIn("renamed1", altered_raw_data[2]["value"]["struct1"]["value"])
+        self.assertNotIn("char1", altered_raw_data[1]["value"]["struct1"])
+        self.assertNotIn("char1", altered_raw_data[2]["value"]["struct1"])
+        self.assertIn("renamed1", altered_raw_data[2]["value"]["struct1"])
+        self.assertIn("renamed1", altered_raw_data[2]["value"]["struct1"])
 
     def test_rename_rest_intact(self):
         altered_raw_data = apply_changes_to_raw_data(
@@ -360,16 +360,13 @@ class FieldStructStructChildBlockTest(TestCase):
         self.assertIn("char2", altered_raw_data[2]["value"]["struct1"])
 
 
-class FieldStreamStreamChildBlockTest(TestCase):
-    pass
+# TODO class FieldStreamStreamChildBlockTest(TestCase):
 
 
-class FieldStreamStructChildBlockTest(TestCase):
-    pass
+# TODO class FieldStreamStructChildBlockTest(TestCase):
 
 
-class FieldListStreamChildBlockTest(TestCase):
-    pass
+# TODO class FieldListStreamChildBlockTest(TestCase):
 
 
 class FieldListStructChildBlockTest(TestCase):

--- a/wagtail_streamfield_migration_toolkit/utils.py
+++ b/wagtail_streamfield_migration_toolkit/utils.py
@@ -1,6 +1,6 @@
 
 
-def apply_changes_to_raw_data(raw_data, block_path, operation_label, *args, **kwargs):
+def apply_changes_to_raw_data(raw_data, block_path, operation, *args, **kwargs):
     altered_raw_data = raw_data
     # Logic will be here 
     return altered_raw_data


### PR DESCRIPTION
Tests by structure

- streamfield -> child
- streamfield -> structblock -> child
- streamfield -> streamblock -> child
- streamfield -> structblock -> streamblock -> child
- streamfield -> structblock -> structblock -> child
- streamfield -> streamblock -> streamblock -> child (not added yet)
- streamfield -> streamblock -> structblock -> child (not added yet)
- streamfield -> listblock -> streamblock -> child (not added yet)
- streamfield -> listblock -> structblock -> child

operations tested 

- rename
- remove

Wagtail factories used where supported for setting up data, rest with json like data.

Added empty `apply_changes_to_raw_data` and operation classes so that they can be called in tests.