### PR TITLE
Old list format

### DIFF
--- a/wagtail_streamfield_migration_toolkit/operations.py
+++ b/wagtail_streamfield_migration_toolkit/operations.py
@@ -1,3 +1,6 @@
+from wagtail_streamfield_migration_toolkit.utils import formatted_list_child_generator
+
+
 class BaseBlockOperation:
     def __init__(self):
         pass
@@ -259,7 +262,6 @@ class StreamChildrenToStructBlockOperation(BaseBlockOperation):
         return mapped_block_value
 
 
-# Note: to remember old list format
 class ListChildrenToStructBlockOperation(BaseBlockOperation):
     def __init__(self, block_name):
         super().__init__()
@@ -267,11 +269,11 @@ class ListChildrenToStructBlockOperation(BaseBlockOperation):
 
     def apply(self, block_value):
         mapped_block_value = []
-        for child_block in block_value:
+
+        # In case there is data from the old list format (wagtail < 2.16), we use the generator
+        # to convert them into the new list format
+        for child_block in formatted_list_child_generator(block_value):
             mapped_block_value.append(
                 {**child_block, "value": {self.block_name: child_block["value"]}}
             )
         return mapped_block_value
-
-
-# TODO BaseListBlockUpgradeOperation

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_old_list.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_old_list.py
@@ -9,10 +9,7 @@ from wagtail_streamfield_migration_toolkit.operations import (
 
 
 class OldListFormatNestedStreamTestCase(TestCase):
-    """TODO complete
-
-    recursion process
-    """
+    """Tests involving changes to ListBlocks in the old format with StreamBlock children"""
 
     @classmethod
     def setUpTestData(cls):
@@ -45,6 +42,15 @@ class OldListFormatNestedStreamTestCase(TestCase):
         cls.raw_data = raw_data
 
     def test_list_converted_to_new_format(self):
+        """Test whether all ListBlock children have converted formats during the recursion.
+
+        This tests the changes done in the recursion process only, so the operation used isn't
+        important. We will use a rename operation for now.
+
+        Check whether each ListBlock child has attributes id, value, type and type is item.
+        Check whether rename operation was done successfully.
+        """
+
         altered_raw_data = apply_changes_to_raw_data(
             self.raw_data,
             "nestedlist_stream.item",
@@ -64,60 +70,27 @@ class OldListFormatNestedStreamTestCase(TestCase):
             self.assertIn("value", listitem)
             self.assertEqual(listitem["type"], "item")
 
-    def test_rename(self):
-        altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data,
-            "nestedlist_stream.item",
-            RenameStreamChildrenOperation(old_name="char1", new_name="renamed1"),
-            streamfield=models.SampleModel.content,
-        )
+        altered_block_path_indices = [
+            (1, 0, 0),
+            (1, 0, 2),
+            (1, 1, 0),
+            (2, 0, 0),
+        ]
 
-        self.assertEqual(
-            altered_raw_data[1]["value"][0]["value"][0]["type"], "renamed1"
-        )
-        self.assertEqual(
-            altered_raw_data[1]["value"][0]["value"][2]["type"], "renamed1"
-        )
-        self.assertEqual(
-            altered_raw_data[1]["value"][1]["value"][0]["type"], "renamed1"
-        )
-        self.assertEqual(
-            altered_raw_data[2]["value"][0]["value"][0]["type"], "renamed1"
-        )
+        for ind0, ind1, ind2 in altered_block_path_indices:
+            self.assertEqual(
+                altered_raw_data[ind0]["value"][ind1]["value"][ind2]["type"], "renamed1"
+            )
 
-        self.assertEqual(
-            altered_raw_data[1]["value"][0]["value"][0]["id"],
-            self.raw_data[1]["value"][0][0]["id"],
-        )
-        self.assertEqual(
-            altered_raw_data[1]["value"][0]["value"][2]["id"],
-            self.raw_data[1]["value"][0][2]["id"],
-        )
-        self.assertEqual(
-            altered_raw_data[1]["value"][1]["value"][0]["id"],
-            self.raw_data[1]["value"][1][0]["id"],
-        )
-        self.assertEqual(
-            altered_raw_data[2]["value"][0]["value"][0]["id"],
-            self.raw_data[2]["value"][0][0]["id"],
-        )
+            self.assertEqual(
+                altered_raw_data[ind0]["value"][ind1]["value"][ind2]["id"],
+                self.raw_data[ind0]["value"][ind1][ind2]["id"],
+            )
 
-        self.assertEqual(
-            altered_raw_data[1]["value"][0]["value"][0]["value"],
-            self.raw_data[1]["value"][0][0]["value"],
-        )
-        self.assertEqual(
-            altered_raw_data[1]["value"][0]["value"][2]["value"],
-            self.raw_data[1]["value"][0][2]["value"],
-        )
-        self.assertEqual(
-            altered_raw_data[1]["value"][1]["value"][0]["value"],
-            self.raw_data[1]["value"][1][0]["value"],
-        )
-        self.assertEqual(
-            altered_raw_data[2]["value"][0]["value"][0]["value"],
-            self.raw_data[2]["value"][0][0]["value"],
-        )
+            self.assertEqual(
+                altered_raw_data[ind0]["value"][ind1]["value"][ind2]["value"],
+                self.raw_data[ind0]["value"][ind1][ind2]["value"],
+            )
 
         self.assertEqual(
             altered_raw_data[1]["value"][0]["value"][1],
@@ -126,10 +99,7 @@ class OldListFormatNestedStreamTestCase(TestCase):
 
 
 class OldListFormatNestedStructTestCase(TestCase):
-    """TODO complete
-
-    recursion process
-    """
+    """Tests involving changes to ListBlocks in the old format with StructBlock children"""
 
     @classmethod
     def setUpTestData(cls):
@@ -154,6 +124,15 @@ class OldListFormatNestedStructTestCase(TestCase):
         cls.raw_data = raw_data
 
     def test_list_converted_to_new_format(self):
+        """Test whether all ListBlock children have converted formats during the recursion.
+
+        This tests the changes done in the recursion process only, so the operation used isn't
+        important. We will use a rename operation for now.
+
+        Check whether each ListBlock child has attributes id, value, type and type is item.
+        Check whether rename operation was done successfully.
+        """
+
         altered_raw_data = apply_changes_to_raw_data(
             self.raw_data,
             "nestedlist_struct.item",
@@ -173,45 +152,20 @@ class OldListFormatNestedStructTestCase(TestCase):
             self.assertIn("value", listitem)
             self.assertEqual(listitem["type"], "item")
 
-    def test_rename(self):
-        altered_raw_data = apply_changes_to_raw_data(
-            self.raw_data,
-            "nestedlist_struct.item",
-            RenameStructChildrenOperation(old_name="char1", new_name="renamed1"),
-            streamfield=models.SampleModel.content,
-        )
+        altered_block_indices = [(1, 0), (1, 1), (2, 0)]
 
-        self.assertNotIn("char1", altered_raw_data[1]["value"][0]["value"])
-        self.assertNotIn("char1", altered_raw_data[1]["value"][1]["value"])
-        self.assertNotIn("char1", altered_raw_data[2]["value"][0]["value"])
-        self.assertIn("renamed1", altered_raw_data[1]["value"][0]["value"])
-        self.assertIn("renamed1", altered_raw_data[1]["value"][1]["value"])
-        self.assertIn("renamed1", altered_raw_data[2]["value"][0]["value"])
-        self.assertEqual(
-            altered_raw_data[1]["value"][0]["value"]["renamed1"],
-            self.raw_data[1]["value"][0]["char1"],
-        )
-        self.assertEqual(
-            altered_raw_data[1]["value"][1]["value"]["renamed1"],
-            self.raw_data[1]["value"][1]["char1"],
-        )
-        self.assertEqual(
-            altered_raw_data[2]["value"][0]["value"]["renamed1"],
-            self.raw_data[2]["value"][0]["char1"],
-        )
+        for ind0, ind1 in altered_block_indices:
+            self.assertNotIn("char1", altered_raw_data[ind0]["value"][ind1]["value"])
+            self.assertIn("renamed1", altered_raw_data[ind0]["value"][ind1]["value"])
 
-        self.assertIn("char2", altered_raw_data[1]["value"][0]["value"])
-        self.assertIn("char2", altered_raw_data[1]["value"][1]["value"])
-        self.assertIn("char2", altered_raw_data[2]["value"][0]["value"])
-        self.assertEqual(
-            altered_raw_data[1]["value"][0]["value"]["char2"],
-            self.raw_data[1]["value"][0]["char2"],
-        )
-        self.assertEqual(
-            altered_raw_data[1]["value"][1]["value"]["char2"],
-            self.raw_data[1]["value"][1]["char2"],
-        )
-        self.assertEqual(
-            altered_raw_data[2]["value"][0]["value"]["char2"],
-            self.raw_data[2]["value"][0]["char2"],
-        )
+            self.assertEqual(
+                altered_raw_data[ind0]["value"][ind1]["value"]["renamed1"],
+                self.raw_data[ind0]["value"][ind1]["char1"],
+            )
+
+            self.assertIn("char2", altered_raw_data[ind0]["value"][ind1]["value"])
+
+            self.assertEqual(
+                altered_raw_data[ind0]["value"][ind1]["value"]["char2"],
+                self.raw_data[ind0]["value"][ind1]["char2"],
+            )

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_old_list.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_old_list.py
@@ -5,6 +5,7 @@ from wagtail_streamfield_migration_toolkit.utils import apply_changes_to_raw_dat
 from wagtail_streamfield_migration_toolkit.operations import (
     RenameStreamChildrenOperation,
     RenameStructChildrenOperation,
+    ListChildrenToStructBlockOperation,
 )
 
 
@@ -41,7 +42,7 @@ class OldListFormatNestedStreamTestCase(TestCase):
         ]
         cls.raw_data = raw_data
 
-    def test_list_converted_to_new_format(self):
+    def test_list_converted_to_new_format_in_recursion(self):
         """Test whether all ListBlock children have converted formats during the recursion.
 
         This tests the changes done in the recursion process only, so the operation used isn't
@@ -97,6 +98,51 @@ class OldListFormatNestedStreamTestCase(TestCase):
             self.raw_data[1]["value"][0][1],
         )
 
+    def test_list_converted_to_new_format_in_operation(self):
+        """Test whether all ListBlock children have converted formats in an operation using the generator
+
+        We will test this with the ListChildrenToStructBlockOperation.
+
+        Check whether each ListBlock child has attributes id, value, type and type is item.
+        Check whether the ListBlock child value is a struct with the previous block as value.
+        Check whether the previous values are intact.
+        """
+
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data,
+            "nestedlist_stream",
+            ListChildrenToStructBlockOperation(block_name="stream1"),
+            streamfield=models.SampleModel.content,
+        )
+
+        for ind, listitem in enumerate(altered_raw_data[1]["value"]):
+            self.assertIsInstance(listitem, dict)
+            self.assertIn("type", listitem)
+            self.assertIn("value", listitem)
+            self.assertEqual(listitem["type"], "item")
+
+            self.assertIsInstance(listitem["value"], dict)
+            self.assertEqual(len(listitem["value"]), 1)
+            self.assertIn("stream1", listitem["value"])
+
+            self.assertEqual(
+                listitem["value"]["stream1"], self.raw_data[1]["value"][ind]
+            )
+
+        for ind, listitem in enumerate(altered_raw_data[2]["value"]):
+            self.assertIsInstance(listitem, dict)
+            self.assertIn("type", listitem)
+            self.assertIn("value", listitem)
+            self.assertEqual(listitem["type"], "item")
+
+            self.assertIsInstance(listitem["value"], dict)
+            self.assertEqual(len(listitem["value"]), 1)
+            self.assertIn("stream1", listitem["value"])
+
+            self.assertEqual(
+                listitem["value"]["stream1"], self.raw_data[2]["value"][ind]
+            )
+
 
 class OldListFormatNestedStructTestCase(TestCase):
     """Tests involving changes to ListBlocks in the old format with StructBlock children"""
@@ -123,7 +169,7 @@ class OldListFormatNestedStructTestCase(TestCase):
         ]
         cls.raw_data = raw_data
 
-    def test_list_converted_to_new_format(self):
+    def test_list_converted_to_new_format_in_recursion(self):
         """Test whether all ListBlock children have converted formats during the recursion.
 
         This tests the changes done in the recursion process only, so the operation used isn't
@@ -168,4 +214,49 @@ class OldListFormatNestedStructTestCase(TestCase):
             self.assertEqual(
                 altered_raw_data[ind0]["value"][ind1]["value"]["char2"],
                 self.raw_data[ind0]["value"][ind1]["char2"],
+            )
+
+    def test_list_converted_to_new_format_in_operation(self):
+        """Test whether all ListBlock children have converted formats in an operation using the generator
+
+        We will test this with the ListChildrenToStructBlockOperation.
+
+        Check whether each ListBlock child has attributes id, value, type and type is item.
+        Check whether the ListBlock child value is a struct with the previous block as value.
+        Check whether the previous values are intact.
+        """
+
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data,
+            "nestedlist_struct",
+            ListChildrenToStructBlockOperation(block_name="struct1"),
+            streamfield=models.SampleModel.content,
+        )
+
+        for ind, listitem in enumerate(altered_raw_data[1]["value"]):
+            self.assertIsInstance(listitem, dict)
+            self.assertIn("type", listitem)
+            self.assertIn("value", listitem)
+            self.assertEqual(listitem["type"], "item")
+
+            self.assertIsInstance(listitem["value"], dict)
+            self.assertEqual(len(listitem["value"]), 1)
+            self.assertIn("struct1", listitem["value"])
+
+            self.assertEqual(
+                listitem["value"]["struct1"], self.raw_data[1]["value"][ind]
+            )
+
+        for ind, listitem in enumerate(altered_raw_data[2]["value"]):
+            self.assertIsInstance(listitem, dict)
+            self.assertIn("type", listitem)
+            self.assertIn("value", listitem)
+            self.assertEqual(listitem["type"], "item")
+
+            self.assertIsInstance(listitem["value"], dict)
+            self.assertEqual(len(listitem["value"]), 1)
+            self.assertIn("struct1", listitem["value"])
+
+            self.assertEqual(
+                listitem["value"]["struct1"], self.raw_data[2]["value"][ind]
             )

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_old_list.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_old_list.py
@@ -71,6 +71,7 @@ class OldListFormatNestedStreamTestCase(TestCase):
             self.assertIn("value", listitem)
             self.assertEqual(listitem["type"], "item")
 
+        # the nested blocks which were renamed
         altered_block_path_indices = [
             (1, 0, 0),
             (1, 0, 2),
@@ -198,6 +199,7 @@ class OldListFormatNestedStructTestCase(TestCase):
             self.assertIn("value", listitem)
             self.assertEqual(listitem["type"], "item")
 
+        # The nested blocks which were renamed
         altered_block_indices = [(1, 0), (1, 1), (2, 0)]
 
         for ind0, ind1 in altered_block_indices:

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_old_list.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_old_list.py
@@ -1,0 +1,217 @@
+from django.test import TestCase
+
+from .. import models
+from wagtail_streamfield_migration_toolkit.utils import apply_changes_to_raw_data
+from wagtail_streamfield_migration_toolkit.operations import (
+    RenameStreamChildrenOperation,
+    RenameStructChildrenOperation,
+)
+
+
+class OldListFormatNestedStreamTestCase(TestCase):
+    """TODO complete
+
+    recursion process
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        raw_data = [
+            {"type": "char1", "id": "0001", "value": "Char Block 1"},
+            {
+                "type": "nestedlist_stream",
+                "id": "0002",
+                "value": [
+                    [
+                        {"type": "char1", "id": "0003", "value": "Char Block 1"},
+                        {"type": "char2", "id": "0004", "value": "Char Block 2"},
+                        {"type": "char1", "id": "0005", "value": "Char Block 1"},
+                    ],
+                    [
+                        {"type": "char1", "id": "0006", "value": "Char Block 1"},
+                    ],
+                ],
+            },
+            {
+                "type": "nestedlist_stream",
+                "id": "0007",
+                "value": [
+                    [
+                        {"type": "char1", "id": "0008", "value": "Char Block 1"},
+                    ]
+                ],
+            },
+        ]
+        cls.raw_data = raw_data
+
+    def test_list_converted_to_new_format(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data,
+            "nestedlist_stream.item",
+            RenameStreamChildrenOperation(old_name="char1", new_name="renamed1"),
+            streamfield=models.SampleModel.content,
+        )
+
+        for listitem in altered_raw_data[1]["value"]:
+            self.assertIsInstance(listitem, dict)
+            self.assertIn("type", listitem)
+            self.assertIn("value", listitem)
+            self.assertEqual(listitem["type"], "item")
+
+        for listitem in altered_raw_data[2]["value"]:
+            self.assertIsInstance(listitem, dict)
+            self.assertIn("type", listitem)
+            self.assertIn("value", listitem)
+            self.assertEqual(listitem["type"], "item")
+
+    def test_rename(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data,
+            "nestedlist_stream.item",
+            RenameStreamChildrenOperation(old_name="char1", new_name="renamed1"),
+            streamfield=models.SampleModel.content,
+        )
+
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"][0]["type"], "renamed1"
+        )
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"][2]["type"], "renamed1"
+        )
+        self.assertEqual(
+            altered_raw_data[1]["value"][1]["value"][0]["type"], "renamed1"
+        )
+        self.assertEqual(
+            altered_raw_data[2]["value"][0]["value"][0]["type"], "renamed1"
+        )
+
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"][0]["id"],
+            self.raw_data[1]["value"][0][0]["id"],
+        )
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"][2]["id"],
+            self.raw_data[1]["value"][0][2]["id"],
+        )
+        self.assertEqual(
+            altered_raw_data[1]["value"][1]["value"][0]["id"],
+            self.raw_data[1]["value"][1][0]["id"],
+        )
+        self.assertEqual(
+            altered_raw_data[2]["value"][0]["value"][0]["id"],
+            self.raw_data[2]["value"][0][0]["id"],
+        )
+
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"][0]["value"],
+            self.raw_data[1]["value"][0][0]["value"],
+        )
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"][2]["value"],
+            self.raw_data[1]["value"][0][2]["value"],
+        )
+        self.assertEqual(
+            altered_raw_data[1]["value"][1]["value"][0]["value"],
+            self.raw_data[1]["value"][1][0]["value"],
+        )
+        self.assertEqual(
+            altered_raw_data[2]["value"][0]["value"][0]["value"],
+            self.raw_data[2]["value"][0][0]["value"],
+        )
+
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"][1],
+            self.raw_data[1]["value"][0][1],
+        )
+
+
+class OldListFormatNestedStructTestCase(TestCase):
+    """TODO complete
+
+    recursion process
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        raw_data = [
+            {"type": "char1", "id": "0001", "value": "Char Block 1"},
+            {
+                "type": "nestedlist_struct",
+                "id": "0002",
+                "value": [
+                    {"char1": "Char Block 1", "char2": "Char Block 2"},
+                    {"char1": "Char Block 1", "char2": "Char Block 2"},
+                ],
+            },
+            {
+                "type": "nestedlist_struct",
+                "id": "0007",
+                "value": [
+                    {"char1": "Char Block 1", "char2": "Char Block 2"},
+                ],
+            },
+        ]
+        cls.raw_data = raw_data
+
+    def test_list_converted_to_new_format(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data,
+            "nestedlist_struct.item",
+            RenameStructChildrenOperation(old_name="char1", new_name="renamed1"),
+            streamfield=models.SampleModel.content,
+        )
+
+        for listitem in altered_raw_data[1]["value"]:
+            self.assertIsInstance(listitem, dict)
+            self.assertIn("type", listitem)
+            self.assertIn("value", listitem)
+            self.assertEqual(listitem["type"], "item")
+
+        for listitem in altered_raw_data[2]["value"]:
+            self.assertIsInstance(listitem, dict)
+            self.assertIn("type", listitem)
+            self.assertIn("value", listitem)
+            self.assertEqual(listitem["type"], "item")
+
+    def test_rename(self):
+        altered_raw_data = apply_changes_to_raw_data(
+            self.raw_data,
+            "nestedlist_struct.item",
+            RenameStructChildrenOperation(old_name="char1", new_name="renamed1"),
+            streamfield=models.SampleModel.content,
+        )
+
+        self.assertNotIn("char1", altered_raw_data[1]["value"][0]["value"])
+        self.assertNotIn("char1", altered_raw_data[1]["value"][1]["value"])
+        self.assertNotIn("char1", altered_raw_data[2]["value"][0]["value"])
+        self.assertIn("renamed1", altered_raw_data[1]["value"][0]["value"])
+        self.assertIn("renamed1", altered_raw_data[1]["value"][1]["value"])
+        self.assertIn("renamed1", altered_raw_data[2]["value"][0]["value"])
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"]["renamed1"],
+            self.raw_data[1]["value"][0]["char1"],
+        )
+        self.assertEqual(
+            altered_raw_data[1]["value"][1]["value"]["renamed1"],
+            self.raw_data[1]["value"][1]["char1"],
+        )
+        self.assertEqual(
+            altered_raw_data[2]["value"][0]["value"]["renamed1"],
+            self.raw_data[2]["value"][0]["char1"],
+        )
+
+        self.assertIn("char2", altered_raw_data[1]["value"][0]["value"])
+        self.assertIn("char2", altered_raw_data[1]["value"][1]["value"])
+        self.assertIn("char2", altered_raw_data[2]["value"][0]["value"])
+        self.assertEqual(
+            altered_raw_data[1]["value"][0]["value"]["char2"],
+            self.raw_data[1]["value"][0]["char2"],
+        )
+        self.assertEqual(
+            altered_raw_data[1]["value"][1]["value"]["char2"],
+            self.raw_data[1]["value"][1]["char2"],
+        )
+        self.assertEqual(
+            altered_raw_data[2]["value"][0]["value"]["char2"],
+            self.raw_data[2]["value"][0]["char2"],
+        )

--- a/wagtail_streamfield_migration_toolkit/utils.py
+++ b/wagtail_streamfield_migration_toolkit/utils.py
@@ -165,10 +165,8 @@ def map_list_block_value(list_block_value, block_def, block_path, **kwargs):
     """
 
     mapped_value = []
+    # In case data is in old list format
     for child_block in formatted_list_child_generator(list_block_value):
-
-        # TODO consider old format, later PR
-        # utility to generate  for new format
 
         mapped_child_value = map_block_value(
             child_block["value"],

--- a/wagtail_streamfield_migration_toolkit/utils.py
+++ b/wagtail_streamfield_migration_toolkit/utils.py
@@ -169,7 +169,7 @@ def map_list_block_value(list_block_value, block_def, block_path, **kwargs):
     """
 
     mapped_value = []
-    for child_block in list_block_value:
+    for child_block in formatted_list_child_generator(list_block_value):
 
         # TODO consider old format, later PR
         # utility to generate  for new format
@@ -184,6 +184,20 @@ def map_list_block_value(list_block_value, block_def, block_path, **kwargs):
         mapped_value.append({**child_block, "value": mapped_child_value})
 
     return mapped_value
+
+
+def formatted_list_child_generator(list_block_value):
+    is_old_format = False
+    if not isinstance(list_block_value[0], dict):
+        is_old_format = True
+    elif "type" not in list_block_value[0] or list_block_value[0]["type"] != "item":
+        is_old_format = True
+
+    for child in list_block_value:
+        if not is_old_format:
+            yield child
+        else:
+            yield {"type": "item", "value": child}
 
 
 def apply_changes_to_raw_data(

--- a/wagtail_streamfield_migration_toolkit/utils.py
+++ b/wagtail_streamfield_migration_toolkit/utils.py
@@ -1,7 +1,5 @@
 from wagtail.blocks import ListBlock, StreamBlock, StructBlock
 
-from wagtail_streamfield_migration_toolkit.operations import BaseBlockOperation
-
 
 # TODO handle block_defs not existing? we'll do this later
 # TODO handle old list format
@@ -13,9 +11,7 @@ def should_alter_block(block_name, block_path):
     return block_name == block_path[0]
 
 
-def map_block_value(
-    block_value, block_def, block_path, operation: BaseBlockOperation, **kwargs
-):
+def map_block_value(block_value, block_def, block_path, operation, **kwargs):
     """
     Maps the value of a block.
 


### PR DESCRIPTION

- generator for converting format if in old list format
- convert old list format to new format in recursion process
- convert old list format to new format in ListChildrenToStructBlockOperation
- tests for above